### PR TITLE
fix: avoid IndexError in get_score_to_perf_map when anchor dict has < 2 entries

### DIFF
--- a/parangonar/match/matchers.py
+++ b/parangonar/match/matchers.py
@@ -13,6 +13,38 @@ import time
 from itertools import combinations
 from scipy.special import binom
 
+
+def _time_tuples_array(
+    time_tuples_by_onset,
+    fallbacks=(),
+):
+    """Build an Nx2 (score_onset, perf_onset) array, sorted by score onset.
+
+    interp1d below requires at least two anchor points. When the
+    refinement dict has 0 or 1 entries (degenerate inputs, e.g. very few
+    performance notes vs the score, or pitch-disjoint pairs) we fall back
+    to the supplied candidate arrays, and finally to an identity map.
+    This prevents IndexError on ``arr[:, 0].argsort()`` when ``arr`` is
+    empty (1-D), which crashes the matcher rather than producing a
+    degenerate-but-usable alignment.
+    """
+    if len(time_tuples_by_onset) >= 2:
+        arr = np.array(
+            [
+                (tup, time_tuples_by_onset[tup])
+                for tup in time_tuples_by_onset.keys()
+            ]
+        )
+    else:
+        arr = None
+        for cand in fallbacks:
+            if cand is not None and len(cand) >= 2:
+                arr = np.asarray(cand)
+                break
+        if arr is None:
+            arr = np.array([[0.0, 0.0], [1.0, 1.0]])
+    return arr[arr[:, 0].argsort()]
+
 from ..dp.dtw import DTW, DTWSL
 from ..dp.nwtw import NW_DTW, NW
 from .. import THEGLUENOTE_CHECKPOINT
@@ -621,13 +653,7 @@ def pitch_and_onset_wise_times(
         s_onset: np.min(time_tuples_by_onset[s_onset])
         for s_onset in time_tuples_by_onset.keys()
     }
-    unique_time_tuples = np.array(
-        [
-            (tup, unique_time_tuples_by_onset[tup])
-            for tup in unique_time_tuples_by_onset.keys()
-        ]
-    )
-    unique_time_tuples = unique_time_tuples[unique_time_tuples[:, 0].argsort()]
+    unique_time_tuples = _time_tuples_array(unique_time_tuples_by_onset)
 
     # unique_time_tuples_by_onset_id = {s_onset_no : np.min(time_tuples_by_onset_id[s_onset_no]) for s_onset_no in time_tuples_by_onset_id.keys()}
     # unique_time_tuples_id = np.array([(tup, unique_time_tuples_by_onset_id[tup]) for tup in unique_time_tuples_by_onset_id.keys()])
@@ -798,13 +824,7 @@ def pitch_and_onset_wise_times_ornament(
         s_onset: np.min(time_tuples_by_onset[s_onset])
         for s_onset in time_tuples_by_onset.keys()
     }
-    unique_time_tuples = np.array(
-        [
-            (tup, unique_time_tuples_by_onset[tup])
-            for tup in unique_time_tuples_by_onset.keys()
-        ]
-    )
-    unique_time_tuples = unique_time_tuples[unique_time_tuples[:, 0].argsort()]
+    unique_time_tuples = _time_tuples_array(unique_time_tuples_by_onset)
 
     return (
         time_tuples_by_onset,
@@ -900,13 +920,7 @@ def pitch_and_onset_wise_times_simple(
         s_onset: np.min(time_tuples_by_onset[s_onset])
         for s_onset in time_tuples_by_onset.keys()
     }
-    unique_time_tuples = np.array(
-        [
-            (tup, unique_time_tuples_by_onset[tup])
-            for tup in unique_time_tuples_by_onset.keys()
-        ]
-    )
-    unique_time_tuples = unique_time_tuples[unique_time_tuples[:, 0].argsort()]
+    unique_time_tuples = _time_tuples_array(unique_time_tuples_by_onset)
 
     return (
         time_tuples_by_onset,
@@ -1081,13 +1095,7 @@ def pitch_and_onset_wise_times_rev(
         s_onset: np.min(time_tuples_by_onset[s_onset])
         for s_onset in time_tuples_by_onset.keys()
     }
-    unique_time_tuples = np.array(
-        [
-            (tup, unique_time_tuples_by_onset[tup])
-            for tup in unique_time_tuples_by_onset.keys()
-        ]
-    )
-    unique_time_tuples = unique_time_tuples[unique_time_tuples[:, 0].argsort()]
+    unique_time_tuples = _time_tuples_array(unique_time_tuples_by_onset)
 
     return (
         time_tuples_by_onset,
@@ -1219,13 +1227,12 @@ def get_score_to_perf_map(
                 additional_time_tuples_by_onset[s_onset]
             )
 
-    unique_time_tuples = np.array(
-        [
-            (tup, unique_time_tuples_by_onset[tup])
-            for tup in unique_time_tuples_by_onset.keys()
-        ]
+    # If refinement found no anchors, fall back to the per-direction
+    # tuples computed earlier in this function.
+    unique_time_tuples = _time_tuples_array(
+        unique_time_tuples_by_onset,
+        fallbacks=(unique_time_tuples_forward, unique_time_tuples_reverse),
     )
-    unique_time_tuples = unique_time_tuples[unique_time_tuples[:, 0].argsort()]
 
     # # DUAL MATCHER -----------------------------------------------------------------------------------
 

--- a/tests/test_degenerate_inputs.py
+++ b/tests/test_degenerate_inputs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Regression tests for matcher behavior on degenerate inputs.
+
+DualDTWNoteMatcher previously crashed with an IndexError when the
+internal `unique_time_tuples_by_onset` dict ended up with fewer than 2
+anchor pairs (e.g., a tiny performance against a much larger score, or
+pitch-disjoint inputs). It should produce a (possibly poor-quality)
+alignment instead, so downstream consumers can decide what to do.
+"""
+
+import unittest
+
+import numpy as np
+import partitura as pt
+import partitura.score as pscore
+
+from parangonar import DualDTWNoteMatcher
+
+
+def _build_short_score():
+    """Build a 4-measure C-major scale Part programmatically."""
+    part = pscore.Part("P0", "scale", quarter_duration=4)
+    part.add(pscore.TimeSignature(4, 4), start=0)
+    pitches = [("C", 4), ("D", 4), ("E", 4), ("F", 4),
+               ("G", 4), ("A", 4), ("B", 4), ("C", 5)]
+    for i, (s, o) in enumerate(pitches):
+        part.add(pscore.Note(step=s, octave=o, alter=None), start=i * 4, end=(i + 1) * 4)
+    pscore.add_measures(part)
+    return part
+
+
+def _perf_note_array(pitches, onsets, durations):
+    """Build a performance note_array directly without round-tripping MIDI."""
+    n = len(pitches)
+    dtype = [
+        ("onset_sec", "f4"),
+        ("duration_sec", "f4"),
+        ("onset_tick", "i4"),
+        ("duration_tick", "i4"),
+        ("pitch", "i4"),
+        ("velocity", "i4"),
+        ("track", "i4"),
+        ("channel", "i4"),
+        ("id", "<U16"),
+    ]
+    arr = np.zeros(n, dtype=dtype)
+    arr["onset_sec"] = onsets
+    arr["duration_sec"] = durations
+    arr["pitch"] = pitches
+    arr["velocity"] = 80
+    arr["id"] = [f"n{i}" for i in range(n)]
+    return arr
+
+
+class TestDegenerateInputs(unittest.TestCase):
+    def setUp(self):
+        self.part = _build_short_score()
+        self.sna = self.part.note_array(include_grace_notes=True)
+
+    def test_one_note_performance_does_not_crash(self):
+        """Aligning a 1-note performance against an 8-note score used to
+        raise IndexError in get_score_to_perf_map; now it returns a list."""
+        pna = _perf_note_array([60], [0.0], [0.5])
+        matcher = DualDTWNoteMatcher()
+        result = matcher(self.sna, pna, process_ornaments=True, score_part=self.part)
+        self.assertIsInstance(result, list)
+
+    def test_pitch_disjoint_performance_does_not_crash(self):
+        """Performance whose pitches are disjoint from the score must not crash."""
+        pna = _perf_note_array([34, 37, 42], [0.0, 0.4, 0.8], [0.3, 0.3, 0.3])
+        matcher = DualDTWNoteMatcher()
+        result = matcher(self.sna, pna, process_ornaments=True, score_part=self.part)
+        self.assertIsInstance(result, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`DualDTWNoteMatcher` crashes with `IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed` whenever the internal `unique_time_tuples_by_onset` dict ends up with 0 or 1 entries. Five sites in `match/matchers.py` build a 2-D anchor array from that dict and then slice with `arr[:, 0]`; when the dict is empty the array is 1-D shape `(0,)` and the slice raises.

This happens in practice when:

- the performance is much smaller than the score (e.g., 1 perf note vs 16 score notes — easy to hit in test harnesses or partial sessions),
- the score and performance pitch sets are disjoint,
- the matcher's refinement pass simply cannot find anchor pairs that satisfy its tolerance checks.

The crash propagates out of `__call__`, so a pipeline that calls the matcher on such inputs blows up entirely instead of producing a degraded-but-usable alignment.

## Repro

```python
import numpy as np
import partitura.score as pscore
from parangonar import DualDTWNoteMatcher

part = pscore.Part("P0", quarter_duration=4)
part.add(pscore.TimeSignature(4, 4), start=0)
for i, (s, o) in enumerate([("C", 4), ("D", 4), ("E", 4), ("F", 4),
                            ("G", 4), ("A", 4), ("B", 4), ("C", 5)]):
    part.add(pscore.Note(step=s, octave=o, alter=None), start=i*4, end=(i+1)*4)
pscore.add_measures(part)

sna = part.note_array(include_grace_notes=True)
pna = np.zeros(1, dtype=[("onset_sec","f4"),("duration_sec","f4"),
    ("onset_tick","i4"),("duration_tick","i4"),("pitch","i4"),
    ("velocity","i4"),("track","i4"),("channel","i4"),("id","<U16")])
pna["pitch"] = 60; pna["duration_sec"] = 0.5; pna["id"] = "n0"

DualDTWNoteMatcher()(sna, pna, process_ornaments=True, score_part=part)
# IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
```

## Fix

Extracts the repeated array-build into one helper `_time_tuples_array(dict_, fallbacks=...)` that:

1. uses the dict when it has ≥ 2 anchor pairs (existing behavior, no change),
2. otherwise falls back to caller-supplied candidate arrays — used at the dual-matcher site for the forward / reverse pass arrays already computed earlier in `get_score_to_perf_map`,
3. otherwise returns identity `(0,0)–(1,1)` so `interp1d` can still construct, and the matcher returns a degenerate alignment instead of crashing.

All five existing call sites in `match/matchers.py` now route through the helper.

Adds `tests/test_degenerate_inputs.py` covering the two reproducers:
- 1-note performance vs 8-note score
- pitch-disjoint performance

No behavior change on non-degenerate inputs (the dict has ≥ 2 entries and the original array-build path is preserved).

## Test plan
- [x] New regression tests pass
- [x] Existing test suite still passes (only failure on my machine is `test_TheGlueNote_align`, which is a separate pre-existing `miditok` × numpy 2.x bug in `miditok/tokenizations/structured.py:92` — unrelated to this PR)