### PR TITLE
fix: define TORCH_AVAILABLE in pretrained_models.py (NameError regression in 3.3.2)

### DIFF
--- a/parangonar/match/pretrained_models.py
+++ b/parangonar/match/pretrained_models.py
@@ -14,6 +14,14 @@ from torch.nn import TransformerEncoder, TransformerEncoderLayer
 from torch.nn.modules.normalization import LayerNorm
 import torch.nn.functional as F
 
+# Referenced by `if not TORCH_AVAILABLE:` guards in AlignmentTransformer.__init__
+# and TheGlueNote.__init__ — without this definition those guards raise NameError
+# (regression first shipped in 3.3.2). The imports above are unconditional, so
+# reaching this line implies torch is importable; truly-optional torch would
+# also require wrapping the imports in try/except and guarding the nn.Module
+# class bodies, which is a larger refactor left to a follow-up.
+TORCH_AVAILABLE = True
+
 
 # ALIGNMENT TRANSFORMER
 


### PR DESCRIPTION
## Bug

In 3.3.2, `if not TORCH_AVAILABLE:` guards were added to `AlignmentTransformer.__init__` (line 56) and `TheGlueNote.__init__` (line 139) to raise a friendly `ImportError` pointing users at `pip install parangonar[accelerated]`. However, `TORCH_AVAILABLE` is never defined in `parangonar/match/pretrained_models.py`.

The result: instantiating either class — or the matcher wrappers `AlignmentTransformerMatcher` / `TheGlueNoteMatcher` that build them — crashes with `NameError` instead of the intended `ImportError` (and instead of just working when torch *is* installed).

## Repro

With `parangonar==3.3.2` (or current `main` HEAD) in an env where torch is installed:

```python
import parangonar as pa
pa.TheGlueNoteMatcher()
```

```
File ".../parangonar/match/pretrained_models.py", line 139, in __init__
    if not TORCH_AVAILABLE:
NameError: name 'TORCH_AVAILABLE' is not defined
```

3.3.0 and 3.3.1 are unaffected because they still define `TORCH_AVAILABLE`.

## Fix

This PR adds `TORCH_AVAILABLE = True` right after the existing unconditional torch imports.

Since `import torch`, `import torch.nn as nn`, etc. at the top of the file are unconditional today, torch is already required to import this module at all. Defining `TORCH_AVAILABLE = True` makes reality and the friendly guards consistent and stops the `NameError`. Verified locally that `TheGlueNote(device=torch.device('cpu'))` and `AlignmentTransformer()` instantiate cleanly with the patch applied.

## Out of scope (for a follow-up)

Truly making torch optional per the guard messages' intent would also need:
- wrapping the top-level torch imports in `try/except`,
- guarding the `nn.Module` subclass bodies (`PositionalEncoding`, `AlignmentTransformer`, `TheGlueNote`) so class definition itself doesn't fail at module load when torch is missing,
- handling `nn.GELU()` as a default argument in `TheGlueNote.__init__` (evaluated at function-definition time).

Happy to take that on in a separate PR if you'd like — wanted to keep this one minimal and focused on un-breaking the regression.